### PR TITLE
Do less calculations in PSP_LockTexture

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -439,9 +439,9 @@ static int PSP_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
     prepareTextureForDownload(texture);
 
     *pixels =
-        (void *)((Uint8 *)psp_tex->data + rect->y * psp_tex->width * SDL_BYTESPERPIXEL(texture->format) +
+        (void *)((Uint8 *)psp_tex->data + rect->y * psp_tex->pitch +
                  rect->x * SDL_BYTESPERPIXEL(texture->format));
-    *pitch = psp_tex->width * SDL_BYTESPERPIXEL(texture->format);
+    *pitch = psp_tex->pitch;
 
     return 0;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a small change, but I didn't see any difference while testing. It should cause a small speed up, but not a noticeable one with most workloads.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
